### PR TITLE
Move dependencies to requirements.txt

### DIFF
--- a/README.md
+++ b/README.md
@@ -22,7 +22,7 @@ The publisher itself requires the following runtime dependencies:
 *  A number of Python packages, install with the following:
 
 ```bash
-pip3 install boto3 psutil requests timeloop
+pip3 install -r requirements.txt
 ```
 
 

--- a/installers/install-osx.bash
+++ b/installers/install-osx.bash
@@ -7,7 +7,7 @@ sysadminctl -addUser _cwpublisher -admin
 
 
 # Install dependencies
-pip3 install boto3 psutil timeloop
+pip3 install -r requirements.txt
 
 
 # Create folders and copy source and config

--- a/installers/install-rpi.bash
+++ b/installers/install-rpi.bash
@@ -7,7 +7,7 @@ useradd -g wheel -s /sbin/nologin cwpublisher
 
 
 # Install dependencies
-pip3 install boto3 psutil timeloop
+pip3 install -r requirements.txt
 
 
 # Create folders and copy source and config

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,4 @@
+boto3
+psutil
+requests
+timeloop


### PR DESCRIPTION
- This should make it easier for anyone who wants to use a virtualenv for development or deployment.
- It also makes sure that the requirements stay in sync between the readme and installers (requests was only in the readme)


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
