### PR TITLE
Add SSM config example

### DIFF
--- a/configs/amazon-cloudwatch-publisher-ssm.json
+++ b/configs/amazon-cloudwatch-publisher-ssm.json
@@ -1,0 +1,24 @@
+{
+  "agent": {
+    "instance": {
+      "prefix": "mi",
+      "command": "sudo cat /var/lib/amazon/ssm/registration | grep -E --only-matching 'mi-[0-9a-f]+' | grep -E --only-matching '[0-9a-f]+'"
+    },
+    "authentication": {
+      "accountId": "ACCOUNT_ID",
+      "userPoolId": "USER_POOL_ID",
+      "identityPoolId": "IDENTITY_POOL_ID",
+      "appClientId": "APP_CLIENT_ID",
+      "password": "PASSWORD"
+    },
+    "region": "REGION",
+    "metrics_collection_interval": 60,
+    "logs_collection_interval": 10,
+    "logfile": "amazon-cloudwatch-publisher.log",
+    "debug": false
+  },
+  "metrics": {
+    "namespace": "System/ManagedInstance"
+  },
+  "logs": {}
+}


### PR DESCRIPTION
The `sudo` and double `grep` is a bit of a hack, but this should give you the managed instance id (`mi-....`)
 as the instance_id

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
